### PR TITLE
Determine the default interface in a programmatic way

### DIFF
--- a/cloud-init/setup_freeipa.sh
+++ b/cloud-init/setup_freeipa.sh
@@ -13,6 +13,11 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# Get the default Ethernet interface
+function get_interface {
+    ip route | grep default | sed "s/^.* dev \([^ ]*\).*$/\1/"
+}
+
 # Get the IP address corresponding to an interface
 function get_ip {
     ip --family inet address show dev "$1" | \
@@ -27,7 +32,8 @@ function get_ptr {
     dig +noall +ans -x "$1" | sed "s/.*PTR[[:space:]]*\(.*\)/\1/"
 }
 
-ip_address=$(get_ip eth0)
+interface=$(get_interface)
+ip_address=$(get_ip "$interface")
 
 # Wait until the IP address has a non-Amazon PTR record before
 # proceeding


### PR DESCRIPTION
Previously the interface was hard coded to eth0.

See also cisagov/freeipa-client-tf-module#4 and cisagov/freeipa-master-tf-module#9.