### PR TITLE
Change default value for variable specifying AMI account ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module "ipa_replica" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI | string | `344440683180` | no |
+| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner. | string | `344440683180` | no |
 | admin_pw | The admin password for the Kerberos admin role | string | | yes |
 | associate_public_ip_address | Whether or not to associate a public IP address with the IPA server | bool | `false` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | string | `t3.medium` | no |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "ipa_replica" {
 
 | Name | Description |
 |------|-------------|
-| id | The EC2 instance ID corresponding to the IPA replica. |
+| replica | The IPA replica EC2 instance. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -39,27 +39,27 @@ module "ipa_replica" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
-| admin_pw | The admin password for the Kerberos admin role | string | | yes |
-| associate_public_ip_address | Whether or not to associate a public IP address with the IPA server | bool | `false` | no |
+| admin_pw | The admin password for the Kerberos admin role. | string | | yes |
+| associate_public_ip_address | Whether or not to associate a public IP address with the IPA server. | bool | `false` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | string | `t3.medium` | no |
-| cert_bucket_name | The name of the AWS S3 bucket where certificates are stored | string | | yes |
-| cert_pw | The password used to protect the PKCS#12 certificates | string | | yes |
-| cert_read_role_arn | The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket | string | | yes |
-| hostname | The hostname of this IPA replica (e.g. `ipa-replica.example.com`) | string | | yes |
+| cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | | yes |
+| cert_pw | The password used to protect the PKCS#12 certificates. | string | | yes |
+| cert_read_role_arn | The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket. | string | | yes |
+| hostname | The hostname of this IPA replica (e.g. `ipa-replica.example.com`). | string | | yes |
 | master_hostname | The hostname of the IPA master (e.g. ipa.example.com).  Only necessary if you want the replica to delay installation until the master becomes available. | string | Empty string | no |
-| private_reverse_zone_id | The zone ID corresponding to the private Route53 reverse zone where the PTR records related to this IPA replica should be created (e.g. `ZKX36JXQ8W82L`) | string | | yes |
-| private_zone_id | The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. `ZKX36JXQ8W82L`) | string | | yes |
+| private_reverse_zone_id | The zone ID corresponding to the private Route53 reverse zone where the PTR records related to this IPA replica should be created (e.g. `ZKX36JXQ8W82L`). | string | | yes |
+| private_zone_id | The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. `ZKX36JXQ8W82L`). | string | | yes |
 | public_zone_id | The zone ID corresponding to the public Route53 zone where the Kerberos-related DNS records should be created (e.g. `ZKX36JXQ8W82L`).  Only required if a public IP address is associated with the IPA replica (i.e. if associate_public_ip_address is true). | string | Empty string | no |
-| server_security_group_id | The ID for the IPA server security group (e.g. sg-0123456789abcdef0) | string | | yes |
-| subnet_id | The ID of the AWS subnet into which to deploy this IPA replica (e.g. `subnet-0123456789abcdef0`) | string | | yes |
-| tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
+| server_security_group_id | The ID for the IPA server security group (e.g. sg-0123456789abcdef0). | string | | yes |
+| subnet_id | The ID of the AWS subnet into which to deploy this IPA replica (e.g. `subnet-0123456789abcdef0`). | string | | yes |
+| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | string | `86400` | no |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| id | The EC2 instance ID corresponding to the IPA replica |
+| id | The EC2 instance ID corresponding to the IPA replica. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module "ipa_replica" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner. | string | `344440683180` | no |
+| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
 | admin_pw | The admin password for the Kerberos admin role | string | | yes |
 | associate_public_ip_address | Whether or not to associate a public IP address with the IPA server | bool | `false` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | string | `t3.medium` | no |

--- a/ami.tf
+++ b/ami.tf
@@ -25,7 +25,6 @@ data "aws_ami" "freeipa" {
     values = ["ebs"]
   }
 
-  # This is the CyHy production (Raytheon) account
   owners      = [var.ami_owner_account_id]
   most_recent = true
 }

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -12,7 +12,7 @@ Note that this example may create resources which cost money. Run
 
 | Name | Description |
 |------|-------------|
-| ipa_client_security_group_id | The ID corresponding to the IPA client security group |
-| ipa_server_security_group_id | The ID corresponding to the IPA server security group |
-| master_id | The EC2 instance ID corresponding to the IPA master |
-| replica_id | The EC2 instance ID corresponding to the IPA replica |
+| ipa_client_security_group | The IPA client security group. |
+| ipa_server_security_group | The IPA server security group. |
+| master | The IPA master EC2 instance. |
+| replica | The IPA replica EC2 instance. |

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -1,8 +1,8 @@
 terraform {
   backend "s3" {
     bucket         = "cisa-cool-terraform-state"
-    encrypt        = true
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
     key            = "freeipa-replica-tf-module/examples/basic_usage/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -1,11 +1,10 @@
 terraform {
   backend "s3" {
-    encrypt        = true
     bucket         = "cisa-cool-terraform-state"
+    encrypt        = true
     dynamodb_table = "terraform-state-lock"
-    region         = "us-east-1"
-    profile        = "cool-user"
-    role_arn       = "arn:aws:iam::608004238745:role/TerraformStateAccess"
     key            = "freeipa-replica-tf-module/examples/basic_usage/terraform.tfstate"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
   }
 }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -112,7 +112,7 @@ module "certreadrole_master" {
   account_ids = [
     data.aws_caller_identity.shared_services.account_id,
   ]
-  cert_bucket_name = "cool-certificates"
+  cert_bucket_name = "cisa-cool-certificates"
   hostname         = "ipa.cal23.cyber.dhs.gov"
 }
 
@@ -126,7 +126,7 @@ module "certreadrole_replica" {
   account_ids = [
     data.aws_caller_identity.shared_services.account_id,
   ]
-  cert_bucket_name = "cool-certificates"
+  cert_bucket_name = "cisa-cool-certificates"
   hostname         = "ipa-replica1.cal23.cyber.dhs.gov"
 }
 

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -56,7 +56,6 @@ resource "aws_route" "route_external_traffic_through_internet_gateway" {
   gateway_id             = aws_internet_gateway.the_igw.id
 }
 
-
 #-------------------------------------------------------------------------------
 # Create a private Route53 zone.
 #-------------------------------------------------------------------------------

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -146,7 +146,7 @@ module "ipa_master" {
   associate_public_ip_address = true
   cert_bucket_name            = "cisa-cool-certificates"
   cert_pw                     = "lemmy"
-  cert_read_role_arn          = module.certreadrole_master.arn
+  cert_read_role_arn          = module.certreadrole_master.role.arn
   directory_service_pw        = "thepassword"
   domain                      = "cal23.cyber.dhs.gov"
   hostname                    = "ipa.cal23.cyber.dhs.gov"
@@ -175,13 +175,13 @@ module "ipa_replica1" {
   associate_public_ip_address = true
   cert_bucket_name            = "cisa-cool-certificates"
   cert_pw                     = "lemmy"
-  cert_read_role_arn          = module.certreadrole_replica.arn
+  cert_read_role_arn          = module.certreadrole_replica.role.arn
   hostname                    = "ipa-replica1.cal23.cyber.dhs.gov"
   master_hostname             = "ipa.cal23.cyber.dhs.gov"
   private_reverse_zone_id     = aws_route53_zone.replica_private_reverse_zone.zone_id
   private_zone_id             = aws_route53_zone.private_zone.zone_id
   public_zone_id              = data.aws_route53_zone.public_zone.zone_id
-  server_security_group_id    = module.ipa_master.server_security_group_id
+  server_security_group_id    = module.ipa_master.server_security_group.id
   subnet_id                   = aws_subnet.replica_subnet.id
   tags = {
     Testing = true

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -1,18 +1,18 @@
 provider "aws" {
-  region  = "us-east-2"
-  profile = "playground"
+  profile = "cool-sharedservices-provisionaccount"
+  region  = "us-east-1"
 }
 
 provider "aws" {
   alias   = "public_dns"
+  profile = "cool-olddns-route53fullaccess"
   region  = "us-east-1"
-  profile = "default"
 }
 
 provider "aws" {
   alias   = "cert_read_role"
+  profile = "cool-dns-provisioncertificatereadroles"
   region  = "us-east-1"
-  profile = "certreadrole-role"
 }
 
 #-------------------------------------------------------------------------------
@@ -108,7 +108,7 @@ module "certreadrole_master" {
   }
 
   account_ids = [
-    "563873274798" # The playground account ID
+    "236526679726" # The COOL Users account
   ]
   cert_bucket_name = "cool-certificates"
   hostname         = "ipa.cal23.cyber.dhs.gov"
@@ -122,7 +122,7 @@ module "certreadrole_replica" {
   }
 
   account_ids = [
-    "563873274798" # The playground account ID
+    "236526679726" # The COOL Users account
   ]
   cert_bucket_name = "cool-certificates"
   hostname         = "ipa-replica1.cal23.cyber.dhs.gov"
@@ -140,8 +140,9 @@ module "ipa_master" {
   }
 
   admin_pw                    = var.admin_pw
+  ami_owner_account_id        = "207871073513" # The COOL Images account
   associate_public_ip_address = true
-  cert_bucket_name            = "cool-certificates"
+  cert_bucket_name            = "cisa-cool-certificates"
   cert_pw                     = "lemmy"
   cert_read_role_arn          = module.certreadrole_master.arn
   directory_service_pw        = "thepassword"
@@ -168,8 +169,9 @@ module "ipa_replica1" {
   }
 
   admin_pw                    = var.admin_pw
+  ami_owner_account_id        = "207871073513" # The COOL Images account
   associate_public_ip_address = true
-  cert_bucket_name            = "cool-certificates"
+  cert_bucket_name            = "cisa-cool-certificates"
   cert_pw                     = "lemmy"
   cert_read_role_arn          = module.certreadrole_replica.arn
   hostname                    = "ipa-replica1.cal23.cyber.dhs.gov"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -26,13 +26,13 @@ resource "aws_vpc" "the_vpc" {
 resource "aws_subnet" "master_subnet" {
   vpc_id            = aws_vpc.the_vpc.id
   cidr_block        = "10.99.48.0/24"
-  availability_zone = "us-east-2a"
+  availability_zone = "us-east-1a"
 }
 
 resource "aws_subnet" "replica_subnet" {
   vpc_id            = aws_vpc.the_vpc.id
   cidr_block        = "10.99.49.0/24"
-  availability_zone = "us-east-2b"
+  availability_zone = "us-east-1b"
 }
 
 #-------------------------------------------------------------------------------

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -99,6 +99,9 @@ data "aws_route53_zone" "public_zone" {
 # Create roles that allows the master and replica to read their certs
 # from S3.
 # -------------------------------------------------------------------------------
+data "aws_caller_identity" "shared_services" {
+}
+
 module "certreadrole_master" {
   source = "github.com/cisagov/cert-read-role-tf-module"
 
@@ -107,7 +110,7 @@ module "certreadrole_master" {
   }
 
   account_ids = [
-    "236526679726" # The COOL Users account
+    data.aws_caller_identity.shared_services.account_id,
   ]
   cert_bucket_name = "cool-certificates"
   hostname         = "ipa.cal23.cyber.dhs.gov"
@@ -121,7 +124,7 @@ module "certreadrole_replica" {
   }
 
   account_ids = [
-    "236526679726" # The COOL Users account
+    data.aws_caller_identity.shared_services.account_id,
   ]
   cert_bucket_name = "cool-certificates"
   hostname         = "ipa-replica1.cal23.cyber.dhs.gov"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -103,7 +103,7 @@ module "certreadrole_master" {
   source = "github.com/cisagov/cert-read-role-tf-module"
 
   providers = {
-    aws = "aws.cert_read_role"
+    aws = aws.cert_read_role
   }
 
   account_ids = [
@@ -117,7 +117,7 @@ module "certreadrole_replica" {
   source = "github.com/cisagov/cert-read-role-tf-module"
 
   providers = {
-    aws = "aws.cert_read_role"
+    aws = aws.cert_read_role
   }
 
   account_ids = [
@@ -134,8 +134,8 @@ module "ipa_master" {
   source = "github.com/cisagov/freeipa-master-tf-module"
 
   providers = {
-    aws            = "aws"
-    aws.public_dns = "aws.public_dns"
+    aws            = aws
+    aws.public_dns = aws.public_dns
   }
 
   admin_pw                    = var.admin_pw
@@ -163,8 +163,8 @@ module "ipa_replica1" {
   source = "../../"
 
   providers = {
-    aws            = "aws"
-    aws.public_dns = "aws.public_dns"
+    aws            = aws
+    aws.public_dns = aws.public_dns
   }
 
   admin_pw                    = var.admin_pw

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -1,19 +1,19 @@
-output "ipa_client_security_group_id" {
-  value       = module.ipa_master.client_security_group_id
-  description = "The ID corresponding to the IPA client security group"
+output "ipa_client_security_group" {
+  value       = module.ipa_master.client_security_group
+  description = "The IPA client security group."
 }
 
-output "ipa_server_security_group_id" {
-  value       = module.ipa_master.server_security_group_id
-  description = "The ID corresponding to the IPA server security group"
+output "ipa_server_security_group" {
+  value       = module.ipa_master.server_security_group
+  description = "The IPA server security group."
 }
 
-output "master_id" {
-  value       = module.ipa_master.id
-  description = "The EC2 instance ID corresponding to the IPA master"
+output "master" {
+  value       = module.ipa_master.master
+  description = "The IPA master EC2 instance."
 }
 
-output "replica_id" {
-  value       = module.ipa_replica1.id
-  description = "The EC2 instance ID corresponding to the IPA replica"
+output "replica" {
+  value       = module.ipa_replica1.replica
+  description = "The IPA replica EC2 instance."
 }

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "admin_pw" {
-  description = "The password for the Kerberos admin role"
+  description = "The password for the Kerberos admin role."
 }
 
 # ------------------------------------------------------------------------------
@@ -16,6 +16,6 @@ variable "admin_pw" {
 
 variable "trusted_cidr_blocks" {
   type        = list(string)
-  description = "A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
+  description = "A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
   default     = []
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "id" {
-  value       = aws_instance.ipa.id
-  description = "The EC2 instance ID corresponding to the IPA server"
+  value       = aws_instance.ipa
+  description = "The IPA replica EC2 instance."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "id" {
+output "replica" {
   value       = aws_instance.ipa
   description = "The IPA replica EC2 instance."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,39 +5,39 @@
 # ------------------------------------------------------------------------------
 
 variable "admin_pw" {
-  description = "The password for the Kerberos admin role"
+  description = "The password for the Kerberos admin role."
 }
 
 variable "cert_bucket_name" {
-  description = "The name of the AWS S3 bucket where certificates are stored"
+  description = "The name of the AWS S3 bucket where certificates are stored."
 }
 
 variable "cert_pw" {
-  description = "The password used to protect the PKCS#12 certificates"
+  description = "The password used to protect the PKCS#12 certificates."
 }
 
 variable "cert_read_role_arn" {
-  description = "The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket"
+  description = "The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket."
 }
 
 variable "hostname" {
-  description = "The hostname of this IPA replica (e.g. ipa-replica.example.com)"
+  description = "The hostname of this IPA replica (e.g. ipa-replica.example.com)."
 }
 
 variable "private_reverse_zone_id" {
-  description = "The zone ID corresponding to the private Route53 reverse zone where the PTR records related to this IPA replica should be created (e.g. ZKX36JXQ8W82L)"
+  description = "The zone ID corresponding to the private Route53 reverse zone where the PTR records related to this IPA replica should be created (e.g. ZKX36JXQ8W82L)."
 }
 
 variable "private_zone_id" {
-  description = "The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. ZKX36JXQ8W82L)"
+  description = "The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. ZKX36JXQ8W82L)."
 }
 
 variable "server_security_group_id" {
-  description = "The ID for the IPA server security group (e.g. sg-0123456789abcdef0)"
+  description = "The ID for the IPA server security group (e.g. sg-0123456789abcdef0)."
 }
 
 variable "subnet_id" {
-  description = "The ID of the AWS subnet into which to deploy this IPA replica (e.g. subnet-0123456789abcdef0)"
+  description = "The ID of the AWS subnet into which to deploy this IPA replica (e.g. subnet-0123456789abcdef0)."
 }
 
 # ------------------------------------------------------------------------------
@@ -54,7 +54,7 @@ variable "ami_owner_account_id" {
 
 variable "associate_public_ip_address" {
   type        = bool
-  description = "Whether or not to associate a public IP address with the IPA replica"
+  description = "Whether or not to associate a public IP address with the IPA replica."
   default     = false
 }
 
@@ -75,7 +75,7 @@ variable "public_zone_id" {
 
 variable "tags" {
   type        = map(string)
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -48,8 +48,8 @@ variable "subnet_id" {
 # ------------------------------------------------------------------------------
 
 variable "ami_owner_account_id" {
-  description = "The ID of the AWS account that owns the FreeIPA server AMI"
-  default     = "563873274798" # CISA NCATS Playground account
+  description = "The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner."
+  default     = "self"
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
## 🗣 Description

In this pull request I:
* Change the default value of the `ami_owner_account_id` variable specifying the account that owns the AMI
* Change outputs to be resources instead of IDs or ARNs

## 💭 Motivation and Context

We need to specify the `ami_owner_account_id` variable for COOL deployment, and I realized that the existing default value no longer made sense.

## 🧪 Testing

I verified that I could deploy the example code to production.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
