### PR TITLE
Remove role and policy name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,25 @@ jobs:
       - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Cache curl downloads
         uses: actions/cache@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mypy_cache
 __pycache__
 .python-version
 .terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/instance_role.tf
+++ b/instance_role.tf
@@ -16,7 +16,6 @@ data "aws_iam_policy_document" "assume_role_doc" {
 # The S3 certificate access role to be used by the IPA replica EC2
 # instance
 resource "aws_iam_role" "ipa" {
-  name               = "ipa_replica_instance_role_${var.hostname}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
 }
 
@@ -47,6 +46,5 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
 
 # The instance profile to be used by the IPA replica EC2 instance.
 resource "aws_iam_instance_profile" "ipa" {
-  name = "ipa_replica_instance_profile_${var.hostname}"
   role = aws_iam_role.ipa.name
 }


### PR DESCRIPTION
## 🗣 Description

Role and policy names are limited to 64 characters, and the names we were using were hitting that limit.  It makes more sense to just let Terraform generate a random name.

## 💭 Motivation and Context

I hit the 64-character limit when trying to deploy our staging environment, which made me realize that the descriptive name is unnecessary.

## 🧪 Testing

I was able to deploy our staging environment once I made these changes.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
